### PR TITLE
[bouncy] add package.xml

### DIFF
--- a/bouncy/package.xml
+++ b/bouncy/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>fastcdr</name>
+  <version>:{version}</version>
+  <description>CDR serialization implementation.</description>
+  <maintainer email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>
+
+

--- a/bouncy/package.xml
+++ b/bouncy/package.xml
@@ -13,5 +13,3 @@
     <build_type>cmake</build_type>
   </export>
 </package>
-
-


### PR DESCRIPTION
The added package.xml is copied from https://github.com/ros2-gbp/fastcdr-release/blob/bf97d9cb57b071f9879c119341cf6c6fdd4c21fd/xenial/package.xml
And changes the use buildtool_depend from ament_cmake to cmake